### PR TITLE
add: aozorafm 新規フィード追加

### DIFF
--- a/src/resources/feed-info-list.ts
+++ b/src/resources/feed-info-list.ts
@@ -25,6 +25,7 @@ export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
   ['30代デザイナーのゆるらじお', 'https://stand.fm/rss/6342440a8fc92d08ba90ce3f'],
   ['AFTERNOON RADIO「デザインのよみかた」', 'https://anchor.fm/s/45d220f4/podcast/rss'],
   ['ajitofm', 'https://ajito.fm/index.xml'],
+  ['aozora.fm', 'https://fortegp05.github.io/aozorafm/feed.xml'],
   ['backspace.fm', 'https://rss.art19.com/backspace'],
   ['BTRAXのCEOによるサンフランシスコ・デザイントーク', 'https://anchor.fm/s/e5f60ec4/podcast/rss'],
   ['e34.fm', 'https://e34.fm/rss.xml'],


### PR DESCRIPTION
私FORTE(フォルテ)が配信しているaozora.fmを追加させていただきました。

テック系オンリーではないですが、私自身ITエンジニアであることと、以下のようにテック系の話題も多いので良かったら追加していただけると幸いです!

[テック系のエピソード一覧](https://fortegp05.hatenablog.com/entry/2024/01/17/201600#%E3%83%86%E3%83%83%E3%82%AFTech%E7%B3%BB)

なお、ローカルでテスト、動作確認して問題ないことを確認しています。

お手数ですが、ご確認・ご対応をお願いいたします。